### PR TITLE
Fix: showing current song info after next song

### DIFF
--- a/app/views/room.html
+++ b/app/views/room.html
@@ -21,13 +21,13 @@
 </div>
 
 <div class="song-info col-md-3">
-    <img src="{{room.song.artworkUrl}}" class="full-width">
-    <h2 class="song-name" ng-bind="room.song.name">Song name</h2>
-    <h3 class="song-artist" ng-bind="room.song.artist.name">Song artist</h3>
+    <img src="{{song.artworkUrl}}" class="full-width">
+    <h2 class="song-name" ng-bind="song.name">Song name</h2>
+    <h3 class="song-artist" ng-bind="song.artist.name">Song artist</h3>
     <h4 class="song-timestamp" ng-bind="makeTimeStamp(progress * song.duration) + ' / ' + makeTimeStamp(song.duration)"></h4>
     <div class="progress-bar">
         <div class="progress-bar-background"></div>
         <div ng-style="{width: progress * 100 + '%'}" class="progress-bar-progress"></div>
     </div>
-    <a class="song-purchase" ng-if="song.purchaseTitle" ng-href="{{song.purchaseUrl}}" target="_blank" ng-bind="room.song.purchaseTitle"></a>
+    <a class="song-purchase" ng-if="song.purchaseTitle" ng-href="{{song.purchaseUrl}}" target="_blank" ng-bind="song.purchaseTitle"></a>
 </div>


### PR DESCRIPTION
The current song information (thumb, title, artist, etc.) was not shown correctly after a next song, because it still used the song from the room response (deprecated) rather than the song from the `now-playing` response (stored in `$rootScope.song`).

*Note* I know this commit / PR should be reapplied to Gijs' refactor branch, but I'm creating an PR so we know that it is fixed, see how it's fixed, can debate on it and do not forget this in the process of merging. 