### PR TITLE
Increase polling interval.

### DIFF
--- a/app/scripts/services/roomService.js
+++ b/app/scripts/services/roomService.js
@@ -74,7 +74,7 @@ angular.module('moodCatApp')
               var currentTime = Math.round($rootScope.sound.currentTime * 1000);
               var timeDiff = nowPlaying.time - currentTime;
 
-              if(Math.abs(timeDiff) > 1000) {
+              if(Math.abs(timeDiff) > 2000) {
                 $rootScope.sound.setCurrentTime(nowPlaying.time / 1000);
                 if(timeDiff < 0) {
                   $rootScope.$broadcast('next-song');


### PR DESCRIPTION
When a client is just a couple of ms slower than the server, it will try to catch on.
However it is then too late, as it polls every second. Then the client is once
again behind and has to adjust again.
This process continues for 4-5 seconds until it is able to catch on.

In the end, the initial loading process is very stuttering which leads to a
worse user experience.